### PR TITLE
updated syntax to Jekyll 3 syntax.

### DIFF
--- a/_layouts/annotation_by_tag.html
+++ b/_layouts/annotation_by_tag.html
@@ -12,7 +12,8 @@ excerpt: Browse annotations by tag.
 
 <h1>Annotations tagged with {{ tag_name }}</h1>
     {% if site.data.tags[page.tag] %}
-        {% for annotation in site.annotations|sort: 'sort_order' %}
+        {% assign sorted_annotations=site.annotations|sort: 'sort_order' %}
+        {% for annotation in sorted_annotations %}
 
         {% if annotation.tags contains page.tag %}
         <div class="media">

--- a/_layouts/volume_page.html
+++ b/_layouts/volume_page.html
@@ -80,26 +80,14 @@ layout: default
     </aside>
 
 {% comment %} Find next/previous pages for navigation.
-Use page.next and page.previous if available (jekyll 3.x),
-otherwise find pages based on index to support Jekyll 2.4 on GitHub Pages.
 {% endcomment %}
 
     {% comment %} Generate zero-based index from 1-based page sort order {% endcomment %}
     {% assign index = page.sort_order|minus:1 %}
 
-    {% if page.previous %}
-      {% assign prev_page = page.previous %}
-    {% elsif index > 0 %}
-      {% assign prev_index = index|minus:1 %}
-      {% assign prev_page = site.volume_pages[prev_index] %}
-    {% endif %}
-    {% if page.next %}
-      {% assign next_page = page.next %}
-    {% elsif index < site.volume_pages.last.sort_order|minus:1 %}
-        {% assign next_index = index|plus:1 %}
-        {% assign next_page = site.volume_pages[next_index] %}
-    {% endif %}
-
+    {% assign prev_page = page.previous %}
+    {% assign next_page = page.next %}
+    
     {% if prev_page %}
     <a class="left carousel-control" href="{{ site.baseurl }}{{ prev_page.url }}" role="button" data-slide="prev" title="Prev: {{ prev_page.title }}" rel="prev">
         <span class="glyphicon glyphicon-chevron-left"></span>


### PR DESCRIPTION
At the time of the original Jekyll theme, Github pages was running a 2.X version of Jekyll.  It's now running 3.8, so the workarounds for the older version are no longer needed (and were causing errors in the 3.8 environments we are developing against.

My only question/concern is whether we should specify Jekyll 3+ in the Gemfile (which doesn't have a jekyll specified at all).  I think it would only matter in environments that were being upgraded from the previous version.  (Readux 1, perhaps?)